### PR TITLE
Add linux aarch64 wheel build support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,50 @@ matrix:
         - MB_PYTHON_VERSION=3.9
         - PLAT=x86_64
 
+    - os: linux
+      arch: arm64
+      dist: xenial
+      language: python
+      python: 3.6
+      env:
+        - MB_PYTHON_VERSION=3.6
+        - PLAT=aarch64
+        - MB_ML_VER=2014
+        - DOCKER_TEST_IMAGE=multibuild/xenial_arm64v8
+
+    - os: linux
+      dist: xenial
+      arch: arm64
+      language: python
+      python: 3.6
+      env:
+        - MB_PYTHON_VERSION=3.7
+        - PLAT=aarch64
+        - MB_ML_VER=2014
+        - DOCKER_TEST_IMAGE=multibuild/xenial_arm64v8
+
+    - os: linux
+      arch: arm64
+      dist: xenial
+      language: python
+      python: 3.6
+      env:
+        - MB_PYTHON_VERSION=3.8
+        - PLAT=aarch64
+        - MB_ML_VER=2014
+        - DOCKER_TEST_IMAGE=multibuild/xenial_arm64v8
+
+    - os: linux
+      arch: arm64
+      dist: xenial
+      language: python
+      python: 3.6
+      env:
+        - MB_PYTHON_VERSION=3.9
+        - PLAT=aarch64
+        - MB_ML_VER=2014
+        - DOCKER_TEST_IMAGE=multibuild/xenial_arm64v8
+
     - os: osx
       env:
         - MB_PYTHON_VERSION=3.6.8


### PR DESCRIPTION
Add linux aarch64 wheel build support. 

Related to https://github.com/ales-erjavec/orange3-wheels/issues/37