### PR TITLE
Remove Python 3.7 wheel builds

### DIFF
--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -17,17 +17,17 @@ jobs:
         include:
           # Linux x86_64
           - os: ubuntu-20.04
-            ciwb-build: "cp{37,38,39,310}-manylinux_x86_64"
+            ciwb-build: "cp{38,39,310}-manylinux_x86_64"
             ciwb-archs: "x86_64"
 
           # Linux aarch64
           - os: ubuntu-20.04
-            ciwb-build: "cp{37,38,39,310}-manylinux_aarch64"
+            ciwb-build: "cp{38,39,310}-manylinux_aarch64"
             ciwb-archs: "aarch64"
 
           # macOS
           - os: macos-11
-            ciwb-build: "cp{37,38,39,310}-macosx_x86_64"
+            ciwb-build: "cp{38,39,310}-macosx_x86_64"
             ciwb-archs: "x86_64"
 
           # macOS
@@ -37,7 +37,7 @@ jobs:
 
           # Windows
           - os: windows-2019
-            ciwb-build: "cp{37,38,39,310}-{win32,win_amd64}"
+            ciwb-build: "cp{38,39,310}-{win32,win_amd64}"
             ciwb-archs: "auto"
 
     steps:


### PR DESCRIPTION
Orange does not support Python 3.7 anymore https://github.com/biolab/orange3/pull/6148
With this PR, I am dropping the 3.7 wheel builds